### PR TITLE
echoerr broken for osx 10.13.6. use alternative method for outputting…

### DIFF
--- a/bootiso
+++ b/bootiso
@@ -13,7 +13,7 @@ scriptName=$(basename "$0")
 bashVersion=$(echo "$BASH_VERSION" | cut -d. -f1)
 
 if [ -z "$BASH_VERSION" ] || [ "$bashVersion" -lt 4 ]; then
-	echoerr "You need bash v4+ to run this script. Aborting..."
+	>&2 echo "You need bash v4+ to run this script. Aborting..."
 	exit 1
 fi
 


### PR DESCRIPTION
… message to stderr

here is a stackoverflow webpage on the change:

https://stackoverflow.com/questions/2990414/echo-that-outputs-to-stderr