### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+RUN apt-get -qq update ; apt-get install -y \
+  extlinux \
+  curl \
+  file \
+  mtools \
+  syslinux \
+  rsync \
+  parted \
+  bc \
+  udev \
+  wimtools
+RUN curl -L https://git.io/bootiso -o /bootiso; chmod +x /bootiso
+CMD echo USAGE:  docker run -it --rm --privileged  -v /your/iso/dir:/data bootiso /bootiso -d /dev/sdX /data/YOURISOFILE.iso

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,26 @@ Where `bin-path` is any folder in the `$PATH` environment, preferably for superu
 
 Make sure to [follow our distro-dependent tweaks](#distro-tweaks) to have bootiso settled.
 
+### Quick install - docker
+
+If your linux distro doesn't have wimlib/wimtools but you have docker installed, you can run bootiso in a container.
+
+Build the image:
+```
+docker build -t 
+```
+
+Start bootiso in a container:
+```
+docker run \
+  -it \
+  --rm \
+  --privileged  \
+  -v /your/iso/dir:/data \
+  bootiso \
+    /bootiso -d /dev/sdX /data/YOURISOFILE.iso
+```
+
 ### Help the community
 
 If you like `bootiso`, feel free to help the community find it by **staring the project** and **upvoting those SE posts**:


### PR DESCRIPTION
I'm trying to use this tool in alpine linux, but I couldn't find a wimlib/wimtools package.
So I figured how about putting the tool into a docker image.

after building the image with `docker build` one could use bootiso like:
```
docker run \
  -it \
  --rm \
  --privileged  \
  -v /your/iso/dir:/data \
  bootiso \
    /bootiso -d /dev/sdX /data/YOURISOFILE.iso
```

If this PR gets accepted, it would make sense to create an automated docker image, so instead of building it manually an "offitial" bootiso/bootiso image could be use. So it could be a **one-liner** to use bootiso.