### PR TITLE
Makefile: make == make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ bash_completions_dir                    = $(datadir)/bash-completion/completions
 
 .PHONY: build install uninstall
 
+all: install
+
 build:
 
 install:


### PR DESCRIPTION
Installing the tool is now so much easier by only running `make`. No one's gonna have to do the hard work of typing `make install` 😅

PS:
I'd appreciate approving || merging || labeling "hacktoberfest-accepted" this PR to count towards my [Hacktober Fest 2020](https://hacktoberfest.digitalocean.com) contributions ending tomorrow Oct 31st.
