### PR TITLE
add support for doas

### DIFF
--- a/bootiso
+++ b/bootiso
@@ -928,7 +928,9 @@ typeset -Ar ct_commandPackages=(
 
 function asrt_checkSudo() {
   if ((EUID != 0)); then
-    if [[ -t 1 ]] && sys_hasCommand sudo; then
+    if [[ -t 1 ]] && sys_hasCommand doas; then
+      doas "$0" "$@"
+    elif sys_hasCommand sudo; then
       sudo --preserve-env "$0" "$@"
     elif sys_hasCommand gksu; then
       exec 1>output_file


### PR DESCRIPTION
bootiso does not check for doas,  as result it shows run as root.
it also fails if doas is symlinked as sudo beacuse of  --preserve-env.
env var can only be preserved by modifying doas conf.
---
name: Pull Request
about: 'Contribute to the project'
title: ''
assignees: jsamr

---

<!--
Thanks for your contribution. Before offering a pull-request, make sure you have
followed these steps:

- Read and complied to the Code Style and Conventions document.
  See: https://git.io/JfFTS
- Run “shellcheck bootiso” and “shfmt -w bootiso” if you changed bootiso file.

In addition, please provide a description of the changes proposed in this pull
request, and explain how did you manually test those changes.

-->
