### PR TITLE
bootiso: substitute invalid characters for vfat partition label

### DIFF
--- a/bootiso
+++ b/bootiso
@@ -1357,6 +1357,8 @@ function devi_configureLabel() {
     targetPartitionLabel=${targetPartitionLabel^^}
     # FAT32 labels have maximum 11 chars
     targetPartitionLabel=${targetPartitionLabel:0:11}
+    # substitute invalid label characters with underscore
+    targetPartitionLabel=${targetPartitionLabel//[][*?.,;:\\\/|+=<>\"]/_}
     ;;
   exfat)
     # EXFAT labels have maximum 15 chars


### PR DESCRIPTION
FAT volume labels do not allow any of these characters:
    * ? . , ; : / \ | + = < > [ ] "
so if found in the ISO volume label, substitute with underscore

---
name: Pull Request
about: 'Contribute to the project'
title: ''
assignees: jsamr

---

<!--
Thanks for your contribution. Before offering a pull-request, make sure you have
followed these steps:

- Read and complied to the Code Style and Conventions document.
  See: https://git.io/JfFTS
- Run “shellcheck bootiso” and “shfmt -w bootiso” if you changed bootiso file.

In addition, please provide a description of the changes proposed in this pull
request, and explain how did you manually test those changes.

-->
