### PR TITLE
exfat: support newer exfatprogs

### DIFF
--- a/bootiso
+++ b/bootiso
@@ -504,10 +504,14 @@ function fs_formatPartition() {
   local -r _fstype=$1
   local -r _targetPart=$2
   local -r _partLabel=$3
+  local _mkfsexfatopts=-n
+  if [[ "$(mkfs.exfat --version)" =~ "exfatprogs "* ]]; then
+    _mkfsexfatopts=-L
+  fi
   # These options always end up with the label flag setter
   local -Ar _mkfsOpts=(
     ['vfat']="-v -F 32 -n" # Fat32 mode
-    ['exfat']="-n"
+    ['exfat']="$_mkfsexfatopts"
     ['ntfs']="-Q -c 4096 -L" # Quick mode + cluster size = 4096 for syslinux support
     ['ext2']="-O ^64bit -L"  # Disabling pure 64 bits compression for syslinux compatibility
     ['ext3']="-O ^64bit -L"  # see https://www.syslinux.org/wiki/index.php?title=Filesystem#ext


### PR DESCRIPTION
---
name: Pull Request
about: 'Contribute to the project'
title: 'exfat: support newer exfatprogs'
assignees: jsamr

---

<!--
Thanks for your contribution. Before offering a pull-request, make sure you have
followed these steps:

- Read and complied to the Code Style and Conventions document.
  See: https://git.io/JfFTS
- Run “shellcheck bootiso” and “shfmt -w bootiso” if you changed bootiso file.

In addition, please provide a description of the changes proposed in this pull
request, and explain how did you manually test those changes.

-->

From Linux 5.7, exFAT was implemented in the kernel tree, exfatprogs is the mainline implementation of exFAT now.